### PR TITLE
fix: sort out CI, fix the table in README and export STTrace fully

### DIFF
--- a/.github/workflows/test-on-mr.yml
+++ b/.github/workflows/test-on-mr.yml
@@ -1,6 +1,9 @@
-name: Release
+name: MR Tests
 on:
   push:
+    branches:
+      - main
+  pull_request:
     branches:
       - main
 jobs:
@@ -18,10 +21,5 @@ jobs:
           node-version: '14.17'
       - name: Install dependencies
         run: npm ci
-      - name: Build
-        run: npm run build:release
-      - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+      - name: Test
+        run: npm run test

--- a/.github/workflows/test-on-mr.yml
+++ b/.github/workflows/test-on-mr.yml
@@ -7,8 +7,8 @@ on:
     branches:
       - main
 jobs:
-  release:
-    name: Release
+  test:
+    name: Spec tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,8 @@
 {
-    "branches": ["master", "next"],
+    "branches": [
+        "main", 
+        "next"
+    ],
     "tagFormat": "${version}",
     "plugins": [
         "@semantic-release/commit-analyzer", 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Some approaches such as segmenting tracks and occluding segments that are out of
 We've summarized the algorithms in this repository, their performance and their drawbacks below:
 
 | Algorith        | Temporal? | Batch                            | Online         |
------------------------------------------------------------------------------------
+|-----------------|-----------|----------------------------------|----------------|
 | Douglas-Peucker | No        | Yes (`O(n log n)`)               | No             |
 | STTrace         | Yes       | Yes (`O(1/n log N/M log M)`)     | Yes (`O(n^2)`) |
 | Bellman's       | No        | Yes (`O(n^2)`)                   | Yes (`O(n^2)`) |

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint lib/**/*.{js,ts} --fix",
     "test": "cross-env jest --coverage",
-    "build": "tsc -p tsconfig.build.json"
+    "build:release": "tsc -p tsconfig.build.json"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,10 @@
 import { DecimateBatch, DecimateOnline } from "./prelude/interfaces/decimate";
-
-export { DecimateBatch, DecimateOnline }
+import { Decimate_STTrace } from "./sttrace/decimate-sttrace";
+const Decimate = {
+    STTrace: Decimate_STTrace
+}
+export { 
+    DecimateBatch, 
+    DecimateOnline, 
+    Decimate
+}


### PR DESCRIPTION
Adds the following:
- MR workflow (so we can use the tests!)
- Changes the release workflow to use the right command to build
- Sorts out an inconsistency on releasrc between internal repo and here (where we used `master`, not `main`)
- Exports `Decimate` on the package root
- Fixes the readme's table