### PR TITLE
fix: implement online mode for sttrace properly, and add matching tests

### DIFF
--- a/src/prelude/interfaces/decimate/online.ts
+++ b/src/prelude/interfaces/decimate/online.ts
@@ -1,3 +1,6 @@
+import { IPoint } from "../point";
+
 export interface DecimateOnline {
-    
+    concat(newPoints:Array<IPoint>):DecimateOnline;
+    toPoints():Array<IPoint>;
 }

--- a/src/sttrace/__tests__/decimate-sttrace.spec.ts
+++ b/src/sttrace/__tests__/decimate-sttrace.spec.ts
@@ -1,3 +1,5 @@
+import { Decimate } from 'index';
+import { DecimateOnline } from 'prelude/interfaces/decimate';
 import { GeoPoint } from '../../prelude';
 import { Decimate_STTrace} from '../decimate-sttrace';
 
@@ -13,6 +15,50 @@ const toGeoPoint = (data:any) => {
     return new GeoPoint(data.lat, data.lon, date);
 }
 describe('Decimate: STTrace', () => {
+    describe('Online mode', () => {
+        it('Returns an empty array for empty paths', () => {
+            const decimatedPath = new Decimate_STTrace(0.7).batch([]);
+            expect(decimatedPath.length).toBe(0);
+        });
+        it('Does nothing on very short paths', () => {
+            const buffer = [
+                new GeoPoint(42, 3.7, new Date(Date.now()+1000)),
+                new GeoPoint(42, 3.7, new Date(Date.now()+2000)),
+            ];
+
+            const decimatedPath = new Decimate_STTrace(0.7).batch(buffer);
+            expect(decimatedPath.length).toBe(2);
+            expect(decimatedPath).not.toContain(new GeoPoint(42, 3.7, new Date(Date.now()+2000)));
+        });
+        it('Never lets the buffer above its maximum value', () => {
+            const buffer = [
+                new GeoPoint(42, 4, new Date()),
+                new GeoPoint(42, 3.7, new Date(Date.now()+1000)),
+                new GeoPoint(42, 3.7, new Date(Date.now()+2000)),
+                new GeoPoint(42, 3.4, new Date(Date.now()+3000))
+            ];
+            let decimatedPathInfo:{path: DecimateOnline, len: Array<number>} = buffer.reduce( ({ path, len }: {path: DecimateOnline, len: Array<number>}, point) => {
+                let oldLength = path.toPoints().length;
+                let newPath = path.concat([point]);
+                return {
+                    path: newPath,
+                    len: [
+                        ...len,
+                        newPath.toPoints().length
+                    ]
+                }
+            }, { 
+                    path: new Decimate_STTrace(0.66),
+                    len: []
+                }
+            );
+            let maxBufferLen = Math.max(...decimatedPathInfo.len);
+            expect(maxBufferLen).not.toBeGreaterThanOrEqual(4);
+            let decimatedPath = decimatedPathInfo.path.toPoints();
+            expect(decimatedPath.length).toBe(3);
+            expect(decimatedPath).not.toContain(new GeoPoint(42, 3.7, new Date(Date.now()+2000)));
+        });
+    })
     describe('Batch mode', () => {
         it('Returns an empty array for empty paths', () => {
             const decimatedPath = new Decimate_STTrace(0.7).batch([]);

--- a/src/sttrace/decimate-sttrace.ts
+++ b/src/sttrace/decimate-sttrace.ts
@@ -14,7 +14,7 @@ export class Decimate_STTrace implements DecimateBatch, DecimateOnline {
     toPoints() {
         return this.points.slice(0);
     }
-    
+
     concat(newPoints: Array<IPoint>):Decimate_STTrace {
         if (!newPoints.length) return this;
         const newTotalSize = this.totalAdded + newPoints.length;
@@ -39,10 +39,19 @@ export class Decimate_STTrace implements DecimateBatch, DecimateOnline {
         this.totalAdded = newTotalSize;
         return this;
     }
+
+    /**
+     * If you would like to change the decimation criteria or function, do it here.
+     * 
+     * @param pointCountToRemove number Number of points to knock out of the buffer
+     * @returns number Number of points removed
+     */
+
     decimateN(pointCountToRemove: number) {
         for (let i = pointCountToRemove; i > 0; i--) {
             this.decimateOne();
         }
+        return pointCountToRemove;
     }
     decimateOne() {
         let toRemoveIdx = null;


### PR DESCRIPTION
- Properly types the `DecimateOnline` interface, clearly denoting methods needing to be implemented
- Implements for STTrace, and covers the implementation with tests guaranteeing that the buffer will not overflow before decimating
- Adds a comment hint on STTrace if anybody ever wants to build a more efficient (or different) decimation function, while keeping the euclidean norm calculations.